### PR TITLE
Change the DB Path directory

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -92,7 +92,7 @@ func Init(cacheDir string) (err error) {
 }
 
 func Path(cacheDir string) string {
-	dbDir = filepath.Join(cacheDir, "db")
+	dbDir = cacheDir
 	dbPath := filepath.Join(dbDir, "trivy.db")
 	return dbPath
 }


### PR DESCRIPTION
1. In order to follow the Zot directory convention, changing the DB Path directory.